### PR TITLE
Use more compact keys, prefer Map to Object

### DIFF
--- a/src/stage.js
+++ b/src/stage.js
@@ -41,10 +41,7 @@ module.exports = class Stage {
     if (x < 0 || x >= this.width) throw new Error("Vixel: set out of bounds.");
     if (y < 0 || y >= this.height) throw new Error("Vixel: set out of bounds.");
     if (z < 0 || z >= this.depth) throw new Error("Vixel: set out of bounds.");
-    this.data.set(this.key(x, y, z), {
-      x,
-      y,
-      z,
+    const vKey = this.vIndex.set({
       red: Math.round(red * 255),
       green: Math.round(green * 255),
       blue: Math.round(blue * 255),
@@ -54,6 +51,7 @@ module.exports = class Stage {
       transparent,
       refract
     });
+    this.data.set(this.key(x, y, z), { x, y, z, vKey });
   }
 
   unset(x, y, z) {
@@ -81,7 +79,7 @@ module.exports = class Stage {
     const aIndex = new Uint8Array(this.textureSize * this.textureSize * 2);
     aIndex.fill(0);
     for (let v of this.data.values()) {
-      const vi = this.vIndex.get(v);
+      const vi = this.vIndex.get(v.vKey);
       const ai = v.y * this.width * this.depth + v.z * this.width + v.x;
       aIndex[ai * 2 + 0] = vi[0];
       aIndex[ai * 2 + 1] = vi[1];

--- a/src/voxel-index.js
+++ b/src/voxel-index.js
@@ -17,10 +17,17 @@ module.exports = class VoxelIndex {
     this.keys = new Map();
   }
 
+  key(v) {
+    const vals = [v.red, v.green, v.blue, v.rough, v.metal, v.emit, v.transparent, v.refract];
+    let h = '';
+    for (let i = 0; i < vals.length; i++) {
+      h += String.fromCharCode(vals[i]);
+    }
+    return h
+  }
+
   set(v) {
-    const h = `${v.red} ${v.green} ${v.blue} ${v.rough} ${v.metal} ${v.emit} ${
-      v.transparent
-    } ${v.refract}`;
+    const h = this.key(v)
     if (!this.keys.has(h)) {
       // It's cool that we're skipping the first two indices, because those will be a shortcut for air and ground.
       this.x++;

--- a/src/voxel-index.js
+++ b/src/voxel-index.js
@@ -14,14 +14,14 @@ module.exports = class VoxelIndex {
     this.aRi.fill(0);
     this.x = 1;
     this.y = 0;
-    this.keys = {};
+    this.keys = new Map();
   }
 
   set(v) {
     const h = `${v.red} ${v.green} ${v.blue} ${v.rough} ${v.metal} ${v.emit} ${
       v.transparent
     } ${v.refract}`;
-    if (this.keys[h] === undefined) {
+    if (!this.keys.has(h)) {
       // It's cool that we're skipping the first two indices, because those will be a shortcut for air and ground.
       this.x++;
       if (this.x > 255) {
@@ -31,7 +31,7 @@ module.exports = class VoxelIndex {
           throw new Error("Exceeded voxel type limit of 65536");
         }
       }
-      this.keys[h] = [this.x, this.y];
+      this.keys.set(h, [this.x, this.y]);
       const i = this.y * 256 + this.x;
       this.aRGB[i * 3 + 0] = v.red;
       this.aRGB[i * 3 + 1] = v.green;
@@ -47,6 +47,6 @@ module.exports = class VoxelIndex {
   }
 
   get(h) {
-    return this.keys[h];
+    return this.keys.get(h);
   }
 };

--- a/src/voxel-index.js
+++ b/src/voxel-index.js
@@ -17,7 +17,7 @@ module.exports = class VoxelIndex {
     this.keys = {};
   }
 
-  get(v) {
+  set(v) {
     const h = `${v.red} ${v.green} ${v.blue} ${v.rough} ${v.metal} ${v.emit} ${
       v.transparent
     } ${v.refract}`;
@@ -42,6 +42,11 @@ module.exports = class VoxelIndex {
       this.aRMET[i * 4 + 3] = v.transparent;
       this.aRi[i * 4 + 0] = v.refract;
     }
+
+    return h;
+  }
+
+  get(h) {
     return this.keys[h];
   }
 };


### PR DESCRIPTION
Hi, first off let me just thank you for an amazing project! I've had so much fun rendering voxel landscapes, a breeze to get started with this. Of course I more or less immediately started to push this to its limits, and encountered some problems when generating large maps.

I think I found some potential improvements:

* Most importantly, using ES6 `Map` instead of `Object` to store the voxels and their index appears to be much faster
* I also made some changes regarding how keys are generated, preferring integers (as much as they exist in JavaScript...) or at least shorter strings as keys to the maps
* Material information was duplicated in the `Stage` as well as in the `VoxelIndex`, so I replaced this with a reference from the `Stage` to the `VoxelIndex`, which saves memory

Using this, I have shaved off something like 40% of the heap size when I generate a 512x32x512 `Vixel`, and time to initialize the map is down from 8 seconds to 6.7, which is not as significant but at least better.

Hope you can find some use for these changes!